### PR TITLE
Fix application disappearing from the taskbar when opening build configuration

### DIFF
--- a/inc/BuildConfigurator.h
+++ b/inc/BuildConfigurator.h
@@ -10,7 +10,7 @@
 #include <QPlainTextEdit>
 #include <QMainWindow>
 
-class BuildConfigurator : public QMainWindow {
+class BuildConfigurator : public QWidget {
     public:
         static constexpr int window_w = 1100;
         static constexpr int window_h = 500;
@@ -32,7 +32,7 @@ class BuildConfigurator : public QMainWindow {
         };
         void printToUser(QString str);
     private:
-        using QMainWindow::QMainWindow;
+        using QWidget::QWidget;
 
         QLineEdit repo_select{"https://github.com/N00byKing/sm64ex", this};
         QLabel repo_select_label{"Repository", this};

--- a/src/BuildConfigurator.cpp
+++ b/src/BuildConfigurator.cpp
@@ -20,7 +20,7 @@
 
 std::string window_title_base = "Build Configurator - ";
 
-BuildConfigurator::BuildConfigurator(QWidget* parent, bool padvanced) : QMainWindow(parent, Qt::Window) {
+BuildConfigurator::BuildConfigurator(QWidget* parent, bool padvanced) : QWidget(parent, Qt::Window) {
     // Load config
     QString default_home = Config::getBuildHome();
     if (default_home != "_None" && default_home != "") {
@@ -83,7 +83,7 @@ void BuildConfigurator::setAdvanced(bool enabled) {
 
 void BuildConfigurator::closeEvent(QCloseEvent *event) {
     LogManager::unlinkFork();
-    parentWidget()->show();
+    parentWidget()->setEnabled(true);
     // No need to delete now. MainWindow will, either on close or on regen
 }
 

--- a/src/BuildConfigurator.h
+++ b/src/BuildConfigurator.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "OutputWidget.h"
+#include <QWidget>
+#include <QLineEdit>
+#include <QWidget>
+#include <QLabel>
+#include <QPushButton>
+#include <QComboBox>
+#include <QPlainTextEdit>
+#include <QMainWindow>
+
+class BuildConfigurator : public QWidget {
+    public:
+        static constexpr int window_w = 1100;
+        static constexpr int window_h = 500;
+        BuildConfigurator(QWidget*,bool);
+        struct SM64_Build_Proto {
+            QString name;
+            QString repo;
+            QString branch;
+            QString directory;
+        };
+        enum struct SM64_Region {
+            Undef, US, JP
+        };
+        struct SM64_Build : SM64_Build_Proto {
+            SM64_Region region;
+            QString make_flags;
+            QStringList patches;
+            QString default_launch_opts = "--sm64ap_name NAME\n--sm64ap_ip archipelago.gg:PORT";
+        };
+        void printToUser(QString str);
+    private:
+        using QWidget::QWidget;
+
+        QLineEdit repo_select{"https://github.com/N00byKing/sm64ex", this};
+        QLabel repo_select_label{"Repository", this};
+        QLineEdit branch_select{"archipelago", this};
+        QLabel branch_select_label{"Branch", this};
+        QPushButton target_directory_button{"Browse...", this};
+        QLabel target_directory_button_label{"Select Target Directory", this};
+        QLabel target_directory_selected_label{"⟶ Currently none selected", this};
+        QLineEdit name_select{"", this};
+        QLabel name_select_label{"Name for this build", this};
+        QPushButton download_files{"Download Files", this};
+        QLabel download_files_label{"Confirm Repo and Branch\nand start downloading the files", this};
+        OutputWidget subprocess_output{this};
+        QComboBox region_select{this};
+        QLabel region_select_label{"Region",this};
+        QLineEdit make_flags{"-j8",this};
+        QLabel make_flags_label{"Make Flags",this};
+        QPushButton apply_patches{"Apply Patches",this};
+        QPushButton start_compile{"Create Build", this};
+        SM64_Build active_build;
+        bool advanced = false;
+        void setLocations();
+        void setAdvanced(bool);
+        void closeEvent(QCloseEvent*);
+        void selectTargetDirectory();
+        void confirmAndDownloadRepo();
+        void selectAndApplyPatches();
+        void PatchApplyCallback(int);
+        void compileBuild();
+        void DLFinishCallback(int);
+        void enableDLInput(bool);
+        void CompileFinishCallback(int);
+        void enableCompileInput(bool);
+};

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -79,14 +79,18 @@ void MainWindow::parseBuilds() {
 
 void MainWindow::spawnDefaultConfigurator() {
     configurator = std::make_unique<BuildConfigurator>(this,false);
+    this->setEnabled(false);
+    configurator->setEnabled(true);
     configurator->show();
-    this->hide();
+    //this->hide();
 }
 
 void MainWindow::spawnAdvancedConfigurator() {
     configurator = std::make_unique<BuildConfigurator>(this,true);
+    this->setEnabled(false);
+    configurator->setEnabled(true);
     configurator->show();
-    this->hide();
+    //this->hide();
 }
 
 void MainWindow::spawnRequirementHandler() {


### PR DESCRIPTION
Fix main window getting hidden when opening build configuration, making the app disappearing from the taskbar, creating a confusion situation for the user.